### PR TITLE
Remove order_by id options

### DIFF
--- a/osmchadjango/changeset/filters.py
+++ b/osmchadjango/changeset/filters.py
@@ -80,7 +80,7 @@ class ChangesetFilter(GeoFilterSet):
         help_text="""Order the Changesets by one of the following fields: id,
             date, check_date, create, modify, delete or number_reasons. Use a
             minus sign (-) before the field name to reverse the ordering.
-            Default ordering is '-id'."""
+            Default ordering is '-date'."""
         )
     hide_whitelist = filters.BooleanFilter(
         field_name='user',
@@ -443,7 +443,7 @@ class ChangesetFilter(GeoFilterSet):
 
     def order_queryset(self, queryset, name, value):
         allowed_fields = [
-            'date', '-date', 'id', 'check_date', '-check_date', 'create',
+            'date', '-date', 'check_date', '-check_date', 'create',
             'modify', 'delete', '-create', '-modify', '-delete',
             'number_reasons', '-number_reasons', 'comments_count',
             '-comments_count'

--- a/osmchadjango/changeset/models.py
+++ b/osmchadjango/changeset/models.py
@@ -119,7 +119,7 @@ class Changeset(models.Model):
             return ""
 
     class Meta:
-        ordering = ['-id']
+        ordering = ['-date']
         indexes = [
             GinIndex(fields=['tag_changes'])
         ]

--- a/osmchadjango/changeset/tests/test_changeset_views.py
+++ b/osmchadjango/changeset/tests/test_changeset_views.py
@@ -380,25 +380,15 @@ class TestChangesetListViewOrdering(APITestCase):
         self.url = reverse('changeset:list')
 
     def test_ordering(self):
-        # default ordering is by descending id
+        # descending date ordering is the default
         response = self.client.get(self.url)
-        ids = [i['id'] for i in response.data.get('features')]
-        self.assertTrue(ids[0] > ids[1])
-
-        # ascending id
-        response = self.client.get(self.url, {'order_by': 'id'})
-        ids = [i['id'] for i in response.data.get('features')]
-        self.assertTrue(ids[0] < ids[1])
+        dates = [i['properties']['date'] for i in response.data.get('features')]
+        self.assertTrue(dates[0] > dates[1])
 
         # ascending date ordering
         response = self.client.get(self.url, {'order_by': 'date'})
         dates = [i['properties']['date'] for i in response.data.get('features')]
         self.assertTrue(dates[0] < dates[1])
-
-        # descending date ordering
-        response = self.client.get(self.url, {'order_by': '-date'})
-        dates = [i['properties']['date'] for i in response.data.get('features')]
-        self.assertTrue(dates[0] > dates[1])
 
         # ascending check_date
         response = self.client.get(self.url, {'order_by': 'check_date'})


### PR DESCRIPTION
Removing ordering by id, as ordering by date would give the same results. It would make queries more efficient, as changesets are commonly filtered by date.