### PR TITLE
Move /health endpoint to /api/v1/health (making it public)

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -8,6 +8,7 @@ from django.contrib import admin
 from django.views import defaults
 from django.views import static as static_views
 from django.http import JsonResponse
+from django.shortcuts import redirect
 
 from rest_framework import permissions
 from drf_yasg.views import get_schema_view
@@ -59,6 +60,9 @@ schema_view = get_schema_view(
     permission_classes=(permissions.AllowAny,),
 )
 
+def health_redirect(request):
+    return redirect(API_BASE_URL + 'health')
+
 def health_check(request):
     return JsonResponse({'status': 'ok'})
 
@@ -66,7 +70,8 @@ urlpatterns += [
     # Django Admin
     path('admin/', admin.site.urls),
 
-    path('health', health_check),
+    path('health', health_redirect),
+    path(API_BASE_URL + 'health', health_check),
 
     # api docs
     re_path(


### PR DESCRIPTION
Currently the `/health` endpoint is not publicly accessible because the nginx config only proxies requests to the backend if they start with `/api`. This change moves the `/health` healthcheck endpoint to `/api/v1/health`, thus making it public facing.

OSM US is starting to use updown.io to check the liveness of various services. Currently we've configured alerts for if https://osmcha.org isn't available, but we haven't set up anything to check that the OSMCha API itself is alive. Once this health check endpoint is available publicly, we can use that to monitor the API server.

I added a redirect from `/health` to `/api/v1/health`. The only current consumer of the `/health` endpoint is Kubernetes' liveness check. Once that's updated to use `/api/v1/health` we can remove the redirect; I only added it so that this change wouldn't break prod if we forgot to also update the helm chart before redeploying.