### PR TITLE
Do not ratelimit the tag-changes endpoint

### DIFF
--- a/osmchadjango/changeset/views.py
+++ b/osmchadjango/changeset/views.py
@@ -698,6 +698,7 @@ def filter_primary_tags(feature):
 class SetChangesetTagChangesAPIView(ModelViewSet):
     queryset = Changeset.objects.all()
     permission_classes = (IsAdminUser,)
+    throttle_classes = [] # do not rate limit the tag changes endpoint
     # The serializer is not used in this view. It's here only to avoid errors
     # in docs schema generation.
     serializer_class = ChangesetStatsSerializer


### PR DESCRIPTION
This endpoint recieves a large volume of requests (one for each new changeset) from a single admin user account. Rate-limiting it will cause tag-changes data to stop being ingested during periods when there are lots of edits happening in OSM, which isn't desirable.

This should fix the bursts of 429 errors that have been happening in the [changeset-adiffs-worker](https://github.com/OSMCha/changeset-adiffs-worker).

<img width="1579" alt="image" src="https://github.com/user-attachments/assets/e46a5d53-0473-4cda-afcd-81f8ac27d6e4" />
